### PR TITLE
Feat: use Makefile conditional instead of shell one

### DIFF
--- a/python/Makefile.style-python
+++ b/python/Makefile.style-python
@@ -9,10 +9,14 @@ BLACK_VERSION := 19.3b0
 BLACK_ARGS    := --line-length 120
 
 lint-python:
-	if [ -n "$(BLACK_PATHS)" ] ; then $(BLACK) -q --check --diff $(BLACK_ARGS) $(BLACK_PATHS) ; fi
+ifneq ($(BLACK_PATHS),)
+	$(BLACK) -q --check --diff $(BLACK_ARGS) $(BLACK_PATHS)
+endif
 
 format-python:
-	if [ -n "$(BLACK_PATHS)" ] ; then $(BLACK) $(BLACK_ARGS) $(BLACK_PATHS) ; fi
+ifneq ($(BLACK_PATHS),)
+	$(BLACK) $(BLACK_ARGS) $(BLACK_PATHS)
+endif
 
 .DEFAULT_GOAL := $(_DEFAULT_GOAL)
 


### PR DESCRIPTION
This is cleaner and removes the action altogether if there are no paths to lint or format.